### PR TITLE
[FIX] 이메일 인증 해야 회원가입 되도록 로직변경

### DIFF
--- a/src/main/java/buravel/buravel/infra/SecurityConfig.java
+++ b/src/main/java/buravel/buravel/infra/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(), accountRepository))
 
                 .authorizeRequests()
-                .mvcMatchers("/signUp", "/login", "/", "/tempPassword", "/findUsername","/index/search").permitAll()
+                .mvcMatchers("/signUp", "/login", "/emailCheckToken", "/", "/tempPassword", "/findUsername","/index/search").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/plans","/plans/{id}").permitAll()
 
                 .anyRequest().authenticated();

--- a/src/main/java/buravel/buravel/modules/account/Account.java
+++ b/src/main/java/buravel/buravel/modules/account/Account.java
@@ -45,12 +45,12 @@ public class Account {
 
     //private LocalDateTime emailCheckTokenGeneratedAt;
 
-    public void generateEmailCheckToken() {
+    /*public void generateEmailCheckToken() {
         String uuid = UUID.randomUUID().toString().replaceAll("-", "");
         uuid = uuid.substring(0, 10);
         this.emailCheckToken = uuid;
         //this.emailCheckTokenGeneratedAt = LocalDateTime.now();
-    }
+    }*/
 
     public boolean isValidToken(String token) {
         return this.emailCheckToken.equals(token);

--- a/src/main/java/buravel/buravel/modules/account/AccountController.java
+++ b/src/main/java/buravel/buravel/modules/account/AccountController.java
@@ -38,12 +38,18 @@ public class AccountController {
             EntityModel<Errors> customError = ErrorResource.modelOf(errors);
             return ResponseEntity.badRequest().body(customError);
         }
+
         Account account = accountService.processNewAccount(accountDto);
+        if(account == null){
+            return ResponseEntity.badRequest().build();
+        } // not email confirm user
+
         EntityModel<Account> accountResource = AccountResource.modelOf(account);
         return ResponseEntity.ok(accountResource);
     }
 
-    @PostMapping("/emailVerification")
+    // 필요 없을 것 같기도 함.
+    /*@PostMapping("/emailVerification")
     public ResponseEntity emailVerification(@CurrentUser Account account, @RequestParam String token){
         Optional<Account> byId = accountRepository.findById(account.getId());
         if (byId.isEmpty()) {
@@ -55,13 +61,13 @@ public class AccountController {
         }
         accountService.completeSignUp(found);
         return ResponseEntity.ok().build();
-    }
+    }*/
 
     //generate new emailCheckToken & re-send token
-    @PostMapping("/emailCheckToken")
-    public ResponseEntity resendEmailCheckToken(@CurrentUser Account account) {
-        accountService.reSendEmailCheckToken(account);
-        return ResponseEntity.ok().build();
+    @PostMapping("/emailCheckToken") // 일단은 이메일만 받음. 필요시 유저정보 전부 받기로 변경
+    public ResponseEntity resendEmailCheckToken(@RequestParam String email) {
+        EmailSendResponseDto dto = accountService.reSendEmailCheckToken(email);
+        return ResponseEntity.ok(dto);
     }
 
     @PostMapping("/tempPassword")

--- a/src/main/java/buravel/buravel/modules/account/AccountDto.java
+++ b/src/main/java/buravel/buravel/modules/account/AccountDto.java
@@ -28,4 +28,6 @@ public class AccountDto {
     @NotBlank
     @Length(min = 8,max = 40)
     private String password;
+
+    private boolean emailVerified;
 }

--- a/src/main/java/buravel/buravel/modules/account/EmailSendResponseDto.java
+++ b/src/main/java/buravel/buravel/modules/account/EmailSendResponseDto.java
@@ -1,0 +1,12 @@
+package buravel.buravel.modules.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailSendResponseDto {
+    private String token;
+}

--- a/src/main/java/buravel/buravel/modules/account/event/AccountEventListener.java
+++ b/src/main/java/buravel/buravel/modules/account/event/AccountEventListener.java
@@ -4,6 +4,7 @@ import buravel.buravel.infra.AppProperties;
 import buravel.buravel.infra.mail.EmailMessage;
 import buravel.buravel.infra.mail.EmailService;
 import buravel.buravel.modules.account.Account;
+import buravel.buravel.modules.account.AccountDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -34,20 +35,20 @@ public class AccountEventListener {
     @EventListener
     public void handleSignUpConfirmEvent(SignUpConfirmEvent event) {
         //throw new RuntimeException();
-        Account account = event.getAccount();
-        sendEmailCheckToken(account);
+        //AccountDto account = event.getAccount();
+        sendEmailCheckToken(event.getEmail(), event.getToken());
     }
 
-    private void sendEmailCheckToken(Account account) {
+    private void sendEmailCheckToken(String email, String token) {
         Context context = new Context(); // model에 내용담아주듯이
-        context.setVariable("token",account.getEmailCheckToken());
-        context.setVariable("username", account.getUsername());
+        context.setVariable("token", token);
+        //context.setVariable("username", account.getUsername()); 아직 가입한 사람이 아니므로 굳이 닉네임 넣을 필요 없어보임
         context.setVariable("message","Buravel 서비스 사용을 위해 코드를 복사하여 붙여넣어주세요.");
 
         String message = templateEngine.process("mail/simple-link", context);
 
         EmailMessage build = EmailMessage.builder()
-                .to(account.getEmail())
+                .to(email)
                 .subject("Buravel 회원 가입 인증")
                 .message(message)
                 .build();

--- a/src/main/java/buravel/buravel/modules/account/event/SignUpConfirmEvent.java
+++ b/src/main/java/buravel/buravel/modules/account/event/SignUpConfirmEvent.java
@@ -1,11 +1,13 @@
 package buravel.buravel.modules.account.event;
 
 import buravel.buravel.modules.account.Account;
+import buravel.buravel.modules.account.AccountDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class SignUpConfirmEvent {
-    private final Account account;
+    private final String email;
+    private final String token;
 }


### PR DESCRIPTION
제가 생각하기에 변경된 로직은,

가입 페이지에서 이메일을 입력하고 '이메일 인증' 버튼을 클릭 
-> /emailCheckToken 으로 들어와서 해당 이메일에 토큰메일 전송. 생성된 토큰을 response에 담아서 보내줌 
-> 프론트가 해당 response를 확인하고 token정보 확인. 
-> 사용자가 이메일로 받은 토큰 입력 후 '인증' 버튼을 클릭 
-> 프론트가 갖고있는 token과 입력한 token이 같은지 확인 (이 부분은 일단 회원가입이 아직 안되어서 백에는 회원 정보가 없기 때문에 백에서 토큰판단이 힘들것 같음) 
-> 토큰이 같으면 프론트가 signUP 할때 emailVerified를 true로 해서 전송 
-> emailVerified된 사용자만 저장

으로 생각해서, 중간에 emailVerified 부분은 필요 없을 것 같긴 합니다. 
좀 급하게 생각대로만 변경한거라 이상한 부분이 있을수 있어서 확인해보시고 의견 맞춰보면 될 것 같습니다.